### PR TITLE
Top panel color tweaks

### DIFF
--- a/qml/Panel/Panel.qml
+++ b/qml/Panel/Panel.qml
@@ -144,7 +144,7 @@ Item {
 
         Rectangle {
             id: panelAreaBackground
-            color: callHint.visible ? theme.palette.normal.positive : theme.palette.normal.background
+            color: callHint.visible ? theme.palette.normal.activity : theme.palette.normal.background
             anchors {
                 top: parent.top
                 left: parent.left


### PR DESCRIPTION
- Top Panel goes green when Dialer is not visible (positive action) but should focus attention (active color in the palette)

![imatge](https://user-images.githubusercontent.com/6640041/70052690-1eab1500-15d4-11ea-9fe6-3b2738676883.png)
